### PR TITLE
Fix pacakge-lint/check-doc/byte-compiler warnings

### DIFF
--- a/ov.el
+++ b/ov.el
@@ -1,4 +1,4 @@
-;;; ov.el --- Overlay library for Emacs Lisp -*- coding: utf-8; lexical-binding: t -*-
+;;; ov.el --- Overlay library for Emacs Lisp  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 by Shingo Fukuyama
 
@@ -6,7 +6,7 @@
 ;; Author: Shingo Fukuyama - http://fukuyama.co
 ;; URL: https://github.com/ShingoFukuyama/ov.el
 ;; Created: Mar 20 2014
-;; Keywords: overlay
+;; Keywords: convenience overlay
 ;; Package-Requires: ((emacs "24.3"))
 
 ;; This program is free software; you can redistribute it and/or
@@ -477,8 +477,7 @@ The arguments are the same as for `ov-prev'."
   "Set KEYBINDS to an overlay or a list of overlays.
 
 If OV-OR-OVS-OR-ID is a symbol, the KEYBINDS will be enabled for
-the entire buffer and the property represented by the symbol to
-`t'.
+the entire buffer and the property represented by the symbol to t.
 
 The overlay is expanded if new inputs are inserted at the
 beginning or end of the buffer."
@@ -509,7 +508,7 @@ beginning or end of the buffer."
 
 ;; Implement pseudo read-only overlay function ---------------------------------
 (defun ov-read-only (ov-or-ovs &optional insert-in-front insert-behind)
-  "Implement a read-only like feature for an overlay or a list of overlays.
+  "Implement a read-only like feature for OV-OR-OVS or a list of overlays.
 
 If INSERT-IN-FRONT is non-nil, inserting in front of each overlay is prevented.
 
@@ -534,6 +533,8 @@ Note that it allows modifications from out of range of a read-only overlay."
                  'insert-behind-hooks '(ov--read-only)))))
 
 (defun ov--read-only (ov after beg end &optional _length)
+  "Modification-hook for read only overlay.
+Called this function with 5 argument; OV, AFTER, BEG, END, _LENGTH."
   (when (and (not (or after
                       undo-in-progress
                       (eq this-command 'undo)
@@ -546,7 +547,7 @@ Note that it allows modifications from out of range of a read-only overlay."
 
 ;; Special overlay -------------------------------------------------------------
 (defun ov-placeholder (ov-or-ovs)
-  "Set a placeholder feature for an overlay or a list of overlays.
+  "Set a placeholder feature for OV-OR-OVS or a list of overlays.
 
 Each overlay deletes its string and overlay, when it is modified."
   (ov-set ov-or-ovs
@@ -556,6 +557,8 @@ Each overlay deletes its string and overlay, when it is modified."
           'insert-behind-hooks '(ov--placeholder)))
 
 (defun ov--placeholder (ov after beg end &optional length)
+  "Modification hooks for placeholder overlay.
+Called this function with 5 arguments; OV, AFTER, BEG, END, LENGTH."
   (let ((inhibit-modification-hooks t))
     (when (not (or undo-in-progress
                    (eq this-command 'undo)
@@ -569,7 +572,7 @@ Each overlay deletes its string and overlay, when it is modified."
 
 ;; Smear background ------------------------------------------------------------
 (defun ov--parse-hex-color (hex)
-  "Convert a hex color code to a RGB list.
+  "Convert a HEX color code to a RGB list.
 i.e.
 #99ccff => (153 204 255)
 #33a    => (51 51 170)"
@@ -637,13 +640,16 @@ Default background color is used when BASE-COLOR is nil."
 (defun ov-smear (regexp-or-list &optional match-end base-color color-range)
   "Set background color overlays to the current buffer.
 Each background color is randomly determined based on BASE-COLOR
-or  the default background color.
+or the default background color.
+
+Optional MATCH-END is used search.
 
 If REGEXP-OR-LIST is regexp
    Set overlays between matches of a regexp.
+
 If REGEXP-OR-LIST is list
    Set overlays between point pairs in a list.
-   i.e. (ov-smear '((1 . 30) (30 . 90))) "
+   i.e. (ov-smear '((1 . 30) (30 . 90)))"
   (interactive "sSplitter: ")
   (ov-clear 'ov-smear)
   (let (points area length (counter 0) ov-list)


### PR DESCRIPTION
Fix pacakge-lint/check-doc/byte-compiler warnings

### after

``` emacs-lisp
 ov.el      9   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 ov.el    480     warning         Symbols t and nil should not appear in single quotes (emacs-lisp-checkdoc)
 ov.el    512     warning         Argument ‘ov-or-ovs’ should appear (as OV-OR-OVS) in the doc string (emacs-lisp-checkdoc)
 ov.el    537     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ov.el    549     warning         Argument ‘ov-or-ovs’ should appear (as OV-OR-OVS) in the doc string (emacs-lisp-checkdoc)
 ov.el    559     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ov.el    572     warning         Argument ‘hex’ should appear (as HEX) in the doc string (emacs-lisp-checkdoc)
 ov.el    638     warning         Argument ‘match-end’ should appear (as MATCH-END) in the doc string (emacs-lisp-checkdoc)
 ov.el    646     warning         Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
```

### before
No errors!